### PR TITLE
StringWithType

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "multipart_form"
-version = "1.0.0"
+version = "1.1.0"
 description = "Small library to generate multipart/form-data requests and parse them"
 licences = ["Apache-2.0"]
 repository = { type = "github", user = "siesta-cat", repo = "gleam_multipart_form" }

--- a/src/multipart_form/field.gleam
+++ b/src/multipart_form/field.gleam
@@ -2,6 +2,7 @@ import gleam/bit_array
 
 pub type FormBody {
   String(String)
+  StringWithType(content: String, content_type: String)
   File(name: String, content_type: String, content: BitArray)
 }
 
@@ -25,6 +26,14 @@ pub fn to_bit_array(
       "Content-Disposition: form-data; name=\"":utf8,
       field:utf8,
       "\"\r\n\r\n":utf8,
+      content:utf8,
+    >>
+    StringWithType(content, type_) -> <<
+      "Content-Disposition: form-data; name=\"":utf8,
+      field:utf8,
+      "\"\r\nContent-Type: ":utf8,
+      type_:utf8,
+      "\r\n\r\n":utf8,
       content:utf8,
     >>
   }

--- a/src/multipart_form/form.gleam
+++ b/src/multipart_form/form.gleam
@@ -76,7 +76,13 @@ fn parse_field(
         bit_array.to_string(body)
         |> result.replace_error("Invalid utf-8 string in string field"),
       )
-      #(field, field.String(content))
+      case list.key_find(headers, "content-type") {
+        Ok(content_type) -> #(
+          field,
+          field.StringWithType(content:, content_type:),
+        )
+        Error(_) -> #(field, field.String(content))
+      }
     }
     option.Some(filename) -> {
       use header <- result.map(

--- a/test/multipart_form_test.gleam
+++ b/test/multipart_form_test.gleam
@@ -34,6 +34,7 @@ pub fn parses_request_test() {
   let expected_form = [
     #("one", field.String("one")),
     #("two", field.String("two")),
+    #("xml", field.StringWithType("xml", "application/xml")),
   ]
 
   let req =
@@ -52,6 +53,8 @@ pub fn parses_request_test() {
       "Content-Disposition: form-data; name=\"one\"\r\n\r\none\r\n":utf8,
       "--9923848\r\n":utf8,
       "Content-Disposition: form-data; name=\"two\"\r\n\r\ntwo\r\n":utf8,
+      "--9923848\r\n":utf8,
+      "Content-Disposition: form-data; name=\"xml\"\r\nContent-Type: application/xml\r\n\r\nxml\r\n":utf8,
       "--9923848--":utf8,
     >>)
 

--- a/test/multipart_form_test.gleam
+++ b/test/multipart_form_test.gleam
@@ -70,6 +70,7 @@ pub fn to_request_test() {
   let form = [
     #("describe", field.String("description")),
     #("content", field.String("disposed")),
+    #("json", field.StringWithType("json", "application/json")),
   ]
 
   let expected_req =
@@ -83,6 +84,8 @@ pub fn to_request_test() {
       "Content-Disposition: form-data; name=\"describe\"\r\n\r\ndescription\r\n":utf8,
       "--gleam_multipart_form\r\n":utf8,
       "Content-Disposition: form-data; name=\"content\"\r\n\r\ndisposed\r\n":utf8,
+      "--gleam_multipart_form\r\n":utf8,
+      "Content-Disposition: form-data; name=\"json\"\r\nContent-Type: application/json\r\n\r\njson\r\n":utf8,
       "--gleam_multipart_form--":utf8,
     >>)
 


### PR DESCRIPTION
The type allows setting the "Content-Type" header for a string, while maintaining backwards compatibility and not removing/altering the previous `String` constructor.

This is useful for sending JSON, for example, as parts are considered "text/plain" as default, which some APIs might not accept.

Also created a unit test :)